### PR TITLE
force to use utf-8 for template processing

### DIFF
--- a/lib/docx_templater/template_processor.rb
+++ b/lib/docx_templater/template_processor.rb
@@ -11,6 +11,7 @@ module DocxTemplater
     end
 
     def render(document)
+      document.force_encoding('utf-8')
       data.each do |key, value|
         if value.class == Array
           document = enter_multiple_values(document, key)


### PR DESCRIPTION
When non-ascii characters like CJK are given in data to template, following error is occurred:

```
/.../ruby-docx-templater/lib/docx_templater/template_processor.rb:19:in `gsub!': incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)
        from /.../ruby-docx-templater/lib/docx_templater/template_processor.rb:19:in `block in render'
        from /.../ruby-docx-templater/lib/docx_templater/template_processor.rb:14:in `each'
        from /.../ruby-docx-templater/lib/docx_templater/template_processor.rb:14:in `render'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:30:in `copy_or_template'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:46:in `block (3 levels) in create_new_zip_in_memory'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:45:in `fopen'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:45:in `block (2 levels) in create_new_zip_in_memory'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:43:in `times'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:43:in `block in create_new_zip_in_memory'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:42:in `open_buffer'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:42:in `create_new_zip_in_memory'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:21:in `block in generate_docx_bytes'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:36:in `block in read_existing_template_docx'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:35:in `open'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:35:in `read_existing_template_docx'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:20:in `generate_docx_bytes'
        from /.../ruby-docx-templater/lib/docx_templater/docx_creator.rb:14:in `generate_docx_file'
        from test.rb:18:in `<main>'
```

This pull request fixes this problem by using utf-8 encoding by default.
This change may work well for other documents since almost DOCXs are utf-8.

I am a newby of Ruby so please use better solution if you have.
