### PR TITLE
don't fail when the templater can't find table markers for an array i…

### DIFF
--- a/lib/docx_templater/template_processor.rb
+++ b/lib/docx_templater/template_processor.rb
@@ -44,7 +44,11 @@ module DocxTemplater
       end_row_template = xml.xpath("//w:tr[contains(., '#{end_row}')]", xml.root.namespaces).first
       DocxTemplater.log("begin_row_template: #{begin_row_template}")
       DocxTemplater.log("end_row_template: #{end_row_template}")
-      fail "unmatched template markers: #{begin_row} nil: #{begin_row_template.nil?}, #{end_row} nil: #{end_row_template.nil?}. This could be because word broke up tags with it's own xml entries. See README." unless begin_row_template && end_row_template
+
+      unless begin_row_template && end_row_template
+        puts "unmatched template markers: #{begin_row} nil: #{begin_row_template.nil?}, #{end_row} nil: #{end_row_template.nil?}. This could be because word broke up tags with it's own xml entries or your template is missing markers for an array of data. See README." 
+        return xml.to_s
+      end
 
       row_templates = []
       row = begin_row_template.next_sibling


### PR DESCRIPTION
don't fail when the templater can't find table markers for an array in the data hash.

basically so that you can use a variety of templates with the same set of data, but won't crash if you only use a small portion of the data.