### PR TITLE
Fix failing 'rake spec' test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'fileutils'
+require 'pathname'
 require 'docx_templater'
 
 SPEC_BASE_PATH = Pathname.new(File.expand_path(File.dirname(__FILE__)))


### PR DESCRIPTION
Hi,

Running 'rake spec' test with Ruby 2.3.0 fails with error:

/Users/russ/Ruby-Docx-Templater/RUSS/ruby-docx-templater/spec/spec_helper.rb:4:in `<top (required)>': uninitialized constant Pathname (NameError)
